### PR TITLE
bugfix: Removed unnecessary `require()`s

### DIFF
--- a/tuyats601.js
+++ b/tuyats601.js
@@ -1,15 +1,8 @@
 const {} = require('zigbee-herdsman-converters/lib/modernExtend');
 // Add the lines below
-const fz = require('zigbee-herdsman-converters/converters/fromZigbee');
-const tz = require('zigbee-herdsman-converters/converters/toZigbee');
 const exposes = require('zigbee-herdsman-converters/lib/exposes');
-const reporting = require('zigbee-herdsman-converters/lib/reporting');
-const extend = require('zigbee-herdsman-converters/lib/extend');
-const ota = require('zigbee-herdsman-converters/lib/ota');
 const tuya = require('zigbee-herdsman-converters/lib/tuya');
 const {} = require('zigbee-herdsman-converters/lib/tuya');
-const utils = require('zigbee-herdsman-converters/lib/utils');
-const globalStore = require('zigbee-herdsman-converters/lib/store');
 const e = exposes.presets;
 const ea = exposes.access;
 


### PR DESCRIPTION
This fixes detecting the device as "Unsupported" by Z2M 1.36.1+.

Removing `zigbee-herdsman-converters/lib/extend` is actually necessary since Z2M 1.36.1: https://github.com/Koenkk/zigbee2mqtt/releases/tag/1.36.1

I've noticed other unsused ones, so I removed them as well.